### PR TITLE
Albion: Fix LLVM and WASM compilation

### DIFF
--- a/SR-games/Albion/SR/llasm/instruction_replacements.sci
+++ b/SR-games/Albion/SR/llasm/instruction_replacements.sci
@@ -82,7 +82,7 @@ loc_BF3C7,3,;cmp eax, 1024|cmovult eax, 1024, tmpcnd, 0, 1|;jb loc_BF411|ctcallz
 
 loc_4D505,4,;or eax, eax|;je loc_4D509|;mov [eax+0x28], dx|ifnz eax|add tmpadr, eax, 40|store16 edx, tmpadr, 1|endif|tcall loc_4D509|endp ; fix reading from NULL pointer
 
-loc_3664B,3,;or edx, edx|;je loc_3664E|;mov al, [edx+0x1]|;loc_3664E:|ifnz edx|add tmpadr, edx, 1|store8 eax, tmpadr, 1|endif ; fix reading from NULL pointer
+loc_3664B,3,;or edx, edx|;je loc_3664E|;mov al, [edx+0x1]|;loc_3664E:|ifnz edx|add tmpadr, edx, 1|load8z eax, tmpadr, 1|endif ; fix reading from NULL pointer
 
 loc_548D4,3,;or eax, eax|;je loc_548D7|;mov al, [eax+0x5]|;loc_548D7:|ifnz eax|add tmpadr, eax, 5|load8z eax, tmpadr, 1|endif ; fix reading from NULL pointer
 loc_5491D,3,;or eax, eax|;je loc_54912|ctcallz eax, loc_54912|tcall loc_54920|endp|proc loc_54920|;add eax, 0x6|add eax, eax, 6 ; fix reading from NULL pointer

--- a/games/Albion/SR-Main/Albion-inout.c
+++ b/games/Albion/SR-Main/Albion-inout.c
@@ -29,10 +29,10 @@
 #include "Game_thread.h"
 #include "display.h"
 
-#define EAX (_eax.e)
-#define AX (_eax.w.x)
-#define AL (_eax.b.l)
-#define AH (_eax.b.h)
+#define EAX (_eax)
+#define AX ((uint16_t)(_eax))
+#define AL ((uint8_t)(_eax))
+#define AH ((uint8_t)((_eax) >> 8))
 
 
 uint32_t palette_index, color_index;
@@ -52,7 +52,7 @@ uint32_t CCALL X86_InPortProcedure(
 void CCALL X86_OutPortProcedure(
     const uint16_t PortNum,
     const uint32_t PortSize,
-    const Game_register _eax)
+    const uint32_t _eax)
 {
     switch (PortNum)
     {

--- a/games/Albion/SR-Main/Albion-inout.h
+++ b/games/Albion/SR-Main/Albion-inout.h
@@ -39,7 +39,7 @@ extern uint32_t CCALL X86_InPortProcedure(
 extern void CCALL X86_OutPortProcedure(
     const uint16_t PortNum,
     const uint32_t PortSize,
-    const Game_register _eax
+    const uint32_t _eax
 );
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes two bugs that manfiest only on LLVM/WASM pipeline:
* The llasm instruction replacements incorrectly use store8 instead of load8z, in code corresponding to the Get_sex function, resulting in bogus data being retrieved and causing all gender-checking functions in the game to fail. Other targets are okay.
* The WASM compiler is not ABI-compatible with x86, resulting in `X86_OutPortProcedure` to mismatch its arguments when `Game_register` is used. This breaks half of the game on WASM, for example resulting in the palette being initialized with all black colors.