### PR TITLE
Albion: Fix 3D scene shining through screens on top of it

### DIFF
--- a/SR-games/Albion/SR/arm/global_aliases.sci
+++ b/SR-games/Albion/SR/arm/global_aliases.sci
@@ -199,3 +199,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/SR-games/Albion/SR/llasm/global_aliases.sci
+++ b/SR-games/Albion/SR/llasm/global_aliases.sci
@@ -195,3 +195,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/SR-games/Albion/SR/x64/global_aliases.sci
+++ b/SR-games/Albion/SR/x64/global_aliases.sci
@@ -199,3 +199,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/SR-games/Albion/SR/x86/global_aliases.sci
+++ b/SR-games/Albion/SR/x86/global_aliases.sci
@@ -199,3 +199,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/games/Albion/SR-Main/Albion-engine.c
+++ b/games/Albion/SR-Main/Albion-engine.c
@@ -1,0 +1,57 @@
+/**
+ *
+ *  Copyright (C) 2016-2026 Roman Pauer
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ *  of the Software, and to permit persons to whom the Software is furnished to do
+ *  so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+#include "Game_defs.h"
+#include "Game_vars.h"
+#include "Albion-engine.h"
+
+#pragma pack(1)
+typedef struct PACKED {
+    uint16_t Flags;
+    uint16_t Type;
+    uint16_t Screen_type;
+    PTR32(void) MainLoop_function;
+    PTR32(void) ModInit_function;
+    PTR32(void) ModExit_function;
+    PTR32(void) DisInit_function;
+    PTR32(void) DisExit_function;
+    PTR32(void) DisUpd_function;
+} Game_Module;
+#pragma pack()
+
+extern Game_Module loc_179164[8]; // stack of screen modules
+extern uint16_t loc_13EEEE; // stack top
+
+uint16_t Game_RootScreenType(void)
+{
+    for (int i = (int) loc_13EEEE; i >= 0; i--)
+    {
+        if (loc_179164[i].Type == 0) /* SCREEN_MOD */
+        {
+            return loc_179164[i].Screen_type;
+        }
+    }
+
+    return GAME_SCREEN_NO_SCREEN;
+}

--- a/games/Albion/SR-Main/Albion-engine.c
+++ b/games/Albion/SR-Main/Albion-engine.c
@@ -43,6 +43,11 @@ typedef struct PACKED {
 extern Game_Module loc_179164[8]; // stack of screen modules
 extern uint16_t loc_13EEEE; // stack top
 
+uint16_t Game_ScreenType(void)
+{
+    return loc_179164[loc_13EEEE].Screen_type;
+}
+
 uint16_t Game_RootScreenType(void)
 {
     for (int i = (int) loc_13EEEE; i >= 0; i--)

--- a/games/Albion/SR-Main/Albion-engine.h
+++ b/games/Albion/SR-Main/Albion-engine.h
@@ -1,0 +1,35 @@
+/**
+ *
+ *  Copyright (C) 2016-2026 Roman Pauer
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ *  of the Software, and to permit persons to whom the Software is furnished to do
+ *  so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+#if !defined(_ALBION_ENGINE_H_INCLUDED_)
+#define _ALBION_ENGINE_H_INCLUDED_
+
+#define GAME_SCREEN_NO_SCREEN 0
+#define GAME_SCREEN_MAP_2D 1
+#define GAME_SCREEN_MAP_3D 2
+#define GAME_SCREEN_DIALOGUE 7
+
+uint16_t Game_RootScreenType(void);
+
+#endif /* _ALBION_ENGINE_H_INCLUDED_ */

--- a/games/Albion/SR-Main/Albion-engine.h
+++ b/games/Albion/SR-Main/Albion-engine.h
@@ -30,6 +30,7 @@
 #define GAME_SCREEN_MAP_3D 2
 #define GAME_SCREEN_DIALOGUE 7
 
+uint16_t Game_ScreenType(void);
 uint16_t Game_RootScreenType(void);
 
 #endif /* _ALBION_ENGINE_H_INCLUDED_ */

--- a/games/Albion/SR-Main/Albion-proc-events.c
+++ b/games/Albion/SR-Main/Albion-proc-events.c
@@ -27,9 +27,16 @@
 #include <string.h>
 #include "Game_defs.h"
 #include "Game_vars.h"
+#include "Albion-engine.h"
 #include "Albion-proc-events.h"
 #include "input.h"
 
+int Game_MovementEnabled(void)
+{
+    uint16_t screen_type = Game_RootScreenType();
+    // 2D or 3D
+    return (screen_type == GAME_SCREEN_MAP_2D) || (screen_type == GAME_SCREEN_MAP_3D);
+}
 
 void Game_ProcessKEvents(void)
 {
@@ -121,7 +128,7 @@ void Game_ProcessKEvents(void)
                         ascii_code = 0;
                     }
 
-                    if (Game_SwitchWSAD)
+                    if (Game_SwitchWSAD && Game_MovementEnabled())
                     {
                         switch(ascii_code)
                         {
@@ -243,7 +250,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_UP:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 'w';
                                 scancode = scancode_table[ascii_code];
@@ -259,7 +266,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_DOWN:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 's';
                                 scancode = scancode_table[ascii_code];
@@ -275,7 +282,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_RIGHT:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 'd';
                                 scancode = scancode_table[ascii_code];
@@ -291,7 +298,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_LEFT:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 'a';
                                 scancode = scancode_table[ascii_code];

--- a/games/Albion/SR-Main/display/pc.c
+++ b/games/Albion/SR-Main/display/pc.c
@@ -24,6 +24,7 @@
 
 #include "../Game_defs.h"
 #include "../Game_vars.h"
+#include "../Albion-engine.h"
 #include "palette32bgra.h"
 #include "overlay.h"
 #include <memory.h>
@@ -43,6 +44,43 @@ static void Set_Palette_Value2(uint32_t index, uint32_t r, uint32_t g, uint32_t 
     Game_PaletteAlpha[index].s.a = 255;
 }
 
+static void Blit_Paletted(uint32_t *dst, const uint8_t *src, uint32_t count, const pixel_format_disp *palette)
+{
+    while (count >= 8)
+    {
+        dst[0] = palette[src[0]].pix;
+        dst[1] = palette[src[1]].pix;
+        dst[2] = palette[src[2]].pix;
+        dst[3] = palette[src[3]].pix;
+        dst[4] = palette[src[4]].pix;
+        dst[5] = palette[src[5]].pix;
+        dst[6] = palette[src[6]].pix;
+        dst[7] = palette[src[7]].pix;
+
+        src += 8;
+        dst += 8;
+        count -= 8;
+    }
+
+    while (count != 0)
+    {
+        dst[0] = palette[src[0]].pix;
+
+        src++;
+        dst++;
+        count--;
+    }
+}
+
+static int SceneVisible(int scene_type)
+{
+    uint16_t screen_type = Game_ScreenType();
+
+    return (screen_type == (uint16_t) scene_type) ||
+           (screen_type == GAME_SCREEN_NO_SCREEN) ||
+           (screen_type == GAME_SCREEN_DIALOGUE);
+}
+
 static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, uint32_t *dst2, int *dst2_used)
 {
     int counter, DrawOverlay;
@@ -50,6 +88,9 @@ static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, 
 
     OverlayInfo = Game_OverlayDisplay;
     DrawOverlay = Get_DrawOverlay(src, &OverlayInfo);
+
+    if (!SceneVisible(GAME_SCREEN_MAP_3D)) DrawOverlay = 0;
+
     *dst2_used = DrawOverlay;
 
     if (DrawOverlay)
@@ -61,20 +102,10 @@ static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, 
         // display part above the viewport
         if (OverlayInfo.ViewportY != 0)
         {
-            for (counter = 360 * OverlayInfo.ViewportY; counter != 0; counter -= 8)
-            {
-                dst1[0] = Game_PaletteAlpha[src[0]].pix;
-                dst1[1] = Game_PaletteAlpha[src[1]].pix;
-                dst1[2] = Game_PaletteAlpha[src[2]].pix;
-                dst1[3] = Game_PaletteAlpha[src[3]].pix;
-                dst1[4] = Game_PaletteAlpha[src[4]].pix;
-                dst1[5] = Game_PaletteAlpha[src[5]].pix;
-                dst1[6] = Game_PaletteAlpha[src[6]].pix;
-                dst1[7] = Game_PaletteAlpha[src[7]].pix;
-
-                src += 8;
-                dst1 += 8;
-            }
+            counter = 360 * OverlayInfo.ViewportY;
+            Blit_Paletted(dst1, src, (uint32_t) counter, Game_PaletteAlpha);
+            src += counter;
+            dst1 += counter;
 
             for (counter = Scaler_ScaleFactor * 360 * Scaler_ScaleFactor * OverlayInfo.ViewportY; counter != 0; counter -= 8)
             {
@@ -100,31 +131,9 @@ static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, 
         {
             for (y = OverlayInfo.ViewportHeight; y != 0; y--)
             {
-                for (x = OverlayInfo.ViewportX; x >= 8; x -= 8)
-                {
-                    dst1[0] = Game_PaletteAlpha[src[0]].pix;
-                    dst1[1] = Game_PaletteAlpha[src[1]].pix;
-                    dst1[2] = Game_PaletteAlpha[src[2]].pix;
-                    dst1[3] = Game_PaletteAlpha[src[3]].pix;
-                    dst1[4] = Game_PaletteAlpha[src[4]].pix;
-                    dst1[5] = Game_PaletteAlpha[src[5]].pix;
-                    dst1[6] = Game_PaletteAlpha[src[6]].pix;
-                    dst1[7] = Game_PaletteAlpha[src[7]].pix;
-
-                    src += 8;
-                    dst1 += 8;
-                }
-
-                for (; x != 0; x--)
-                {
-                    dst1[0] = Game_PaletteAlpha[src[0]].pix;
-
-                    src++;
-                    dst1++;
-                }
-
-                src += (360 - OverlayInfo.ViewportX);
-                dst1 += (360 - OverlayInfo.ViewportX);
+                Blit_Paletted(dst1, src, OverlayInfo.ViewportX, Game_PaletteAlpha);
+                src += 360;
+                dst1 += 360;
             }
 
             for (y = Scaler_ScaleFactor * OverlayInfo.ViewportHeight; y != 0; y--)
@@ -164,31 +173,9 @@ static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, 
 
             for (y = OverlayInfo.ViewportHeight; y != 0; y--)
             {
-                for (x = ViewportX2; x >= 8; x -= 8)
-                {
-                    dst1[0] = Game_PaletteAlpha[src[0]].pix;
-                    dst1[1] = Game_PaletteAlpha[src[1]].pix;
-                    dst1[2] = Game_PaletteAlpha[src[2]].pix;
-                    dst1[3] = Game_PaletteAlpha[src[3]].pix;
-                    dst1[4] = Game_PaletteAlpha[src[4]].pix;
-                    dst1[5] = Game_PaletteAlpha[src[5]].pix;
-                    dst1[6] = Game_PaletteAlpha[src[6]].pix;
-                    dst1[7] = Game_PaletteAlpha[src[7]].pix;
-
-                    src += 8;
-                    dst1 += 8;
-                }
-
-                for (; x != 0; x--)
-                {
-                    dst1[0] = Game_PaletteAlpha[src[0]].pix;
-
-                    src++;
-                    dst1++;
-                }
-
-                src += (360 - ViewportX2);
-                dst1 += (360 - ViewportX2);
+                Blit_Paletted(dst1, src, (uint32_t) ViewportX2, Game_PaletteAlpha);
+                src += 360;
+                dst1 += 360;
             }
 
             for (y = Scaler_ScaleFactor * OverlayInfo.ViewportHeight; y != 0; y--)
@@ -223,20 +210,10 @@ static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, 
         dst1 = zaldst1 + (360 * OverlayInfo.ViewportHeight);
         dst2 = zaldst2 + Scaler_ScaleFactor * Scaler_ScaleFactor * (360 * OverlayInfo.ViewportHeight);
 
-        for (counter = 360 * (240 - (OverlayInfo.ViewportY + OverlayInfo.ViewportHeight)); counter != 0; counter -= 8)
-        {
-            dst1[0] = Game_PaletteAlpha[src[0]].pix;
-            dst1[1] = Game_PaletteAlpha[src[1]].pix;
-            dst1[2] = Game_PaletteAlpha[src[2]].pix;
-            dst1[3] = Game_PaletteAlpha[src[3]].pix;
-            dst1[4] = Game_PaletteAlpha[src[4]].pix;
-            dst1[5] = Game_PaletteAlpha[src[5]].pix;
-            dst1[6] = Game_PaletteAlpha[src[6]].pix;
-            dst1[7] = Game_PaletteAlpha[src[7]].pix;
-
-            src += 8;
-            dst1 += 8;
-        }
+        counter = 360 * (240 - (OverlayInfo.ViewportY + OverlayInfo.ViewportHeight));
+        Blit_Paletted(dst1, src, (uint32_t) counter, Game_PaletteAlpha);
+        src += counter;
+        dst1 += counter;
 
         for (counter = Scaler_ScaleFactor * 360 * Scaler_ScaleFactor * (240 - (OverlayInfo.ViewportY + OverlayInfo.ViewportHeight)); counter != 0; counter -= 8)
         {
@@ -389,20 +366,7 @@ static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, 
     }
     else
     {
-        for (counter = 360*240; counter != 0; counter -= 8)
-        {
-            dst1[0] = Game_Palette[src[0]].pix;
-            dst1[1] = Game_Palette[src[1]].pix;
-            dst1[2] = Game_Palette[src[2]].pix;
-            dst1[3] = Game_Palette[src[3]].pix;
-            dst1[4] = Game_Palette[src[4]].pix;
-            dst1[5] = Game_Palette[src[5]].pix;
-            dst1[6] = Game_Palette[src[6]].pix;
-            dst1[7] = Game_Palette[src[7]].pix;
-
-            src += 8;
-            dst1 += 8;
-        }
+        Blit_Paletted(dst1, src, 360 * 240, Game_Palette);
     }
 }
 
@@ -415,6 +379,8 @@ static void Flip_360x240x8_to_720x480x32(uint8_t *src, uint32_t *dst)
 
     OverlayInfo = Game_OverlayDisplay;
     DrawOverlay = Get_DrawOverlay(src, &OverlayInfo);
+
+    if (!SceneVisible(GAME_SCREEN_MAP_3D)) DrawOverlay = 0;
 
     if (DrawOverlay)
     {

--- a/games/Albion/SR-Main/display/pc.c
+++ b/games/Albion/SR-Main/display/pc.c
@@ -74,11 +74,9 @@ static void Blit_Paletted(uint32_t *dst, const uint8_t *src, uint32_t count, con
 
 static int SceneVisible(int scene_type)
 {
-    uint16_t screen_type = Game_ScreenType();
+    uint16_t screen_type = Game_RootScreenType();
 
-    return (screen_type == (uint16_t) scene_type) ||
-           (screen_type == GAME_SCREEN_NO_SCREEN) ||
-           (screen_type == GAME_SCREEN_DIALOGUE);
+    return (screen_type == scene_type) || (screen_type == GAME_SCREEN_DIALOGUE);
 }
 
 static void Flip_360x240x8_to_360x240x32_advanced(uint8_t *src, uint32_t *dst1, uint32_t *dst2, int *dst2_used)


### PR DESCRIPTION
The enhanced 3D path activates when 3D rendering is on, but that also occurs in situations when there is another screen on top, such as when the main menu or inventory screen is open. This results in pixels of the high-res 3D scene appearing through the screen on top in locations where the palette indices accidentally match.

The fix imports the `Game_Module` and checks if the fully-opaque screen on top is actually the 3D scene.