### PR TITLE
Albion: Disable WSAD switch when the game is not in movement mode

### DIFF
--- a/SR-games/Albion/SR/arm/global_aliases.sci
+++ b/SR-games/Albion/SR/arm/global_aliases.sci
@@ -199,3 +199,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/SR-games/Albion/SR/llasm/global_aliases.sci
+++ b/SR-games/Albion/SR/llasm/global_aliases.sci
@@ -195,3 +195,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/SR-games/Albion/SR/x64/global_aliases.sci
+++ b/SR-games/Albion/SR/x64/global_aliases.sci
@@ -199,3 +199,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/SR-games/Albion/SR/x86/global_aliases.sci
+++ b/SR-games/Albion/SR/x86/global_aliases.sci
@@ -199,3 +199,6 @@ loc_196D0E,loc_196D0E
 
 loc_17E164,loc_17E164
 loc_182010,loc_182010
+
+loc_13EEEE,loc_13EEEE
+loc_179164,loc_179164

--- a/games/Albion/SR-Main/Albion-engine.c
+++ b/games/Albion/SR-Main/Albion-engine.c
@@ -1,0 +1,57 @@
+/**
+ *
+ *  Copyright (C) 2016-2026 Roman Pauer
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ *  of the Software, and to permit persons to whom the Software is furnished to do
+ *  so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+#include "Game_defs.h"
+#include "Game_vars.h"
+#include "Albion-engine.h"
+
+#pragma pack(1)
+typedef struct PACKED {
+    uint16_t Flags;
+    uint16_t Type;
+    uint16_t Screen_type;
+    PTR32(void) MainLoop_function;
+    PTR32(void) ModInit_function;
+    PTR32(void) ModExit_function;
+    PTR32(void) DisInit_function;
+    PTR32(void) DisExit_function;
+    PTR32(void) DisUpd_function;
+} Game_Module;
+#pragma pack()
+
+extern Game_Module loc_179164[8]; // stack of screen modules
+extern uint16_t loc_13EEEE; // stack top
+
+uint16_t Game_RootScreenType(void)
+{
+    for (int i = (int) loc_13EEEE; i >= 0; i--)
+    {
+        if (loc_179164[i].Type == 0) /* SCREEN_MOD */
+        {
+            return loc_179164[i].Screen_type;
+        }
+    }
+
+    return GAME_SCREEN_NO_SCREEN;
+}

--- a/games/Albion/SR-Main/Albion-engine.h
+++ b/games/Albion/SR-Main/Albion-engine.h
@@ -1,0 +1,35 @@
+/**
+ *
+ *  Copyright (C) 2016-2026 Roman Pauer
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ *  of the Software, and to permit persons to whom the Software is furnished to do
+ *  so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+#if !defined(_ALBION_ENGINE_H_INCLUDED_)
+#define _ALBION_ENGINE_H_INCLUDED_
+
+#define GAME_SCREEN_NO_SCREEN 0
+#define GAME_SCREEN_MAP_2D 1
+#define GAME_SCREEN_MAP_3D 2
+#define GAME_SCREEN_DIALOGUE 7
+
+uint16_t Game_RootScreenType(void);
+
+#endif /* _ALBION_ENGINE_H_INCLUDED_ */

--- a/games/Albion/SR-Main/Albion-proc-events.c
+++ b/games/Albion/SR-Main/Albion-proc-events.c
@@ -27,9 +27,16 @@
 #include <string.h>
 #include "Game_defs.h"
 #include "Game_vars.h"
+#include "Albion-engine.h"
 #include "Albion-proc-events.h"
 #include "input.h"
 
+int Game_MovementEnabled(void)
+{
+    uint16_t screen_type = Game_RootScreenType();
+    // 2D or 3D
+    return (screen_type == GAME_SCREEN_MAP_2D) || (screen_type == GAME_SCREEN_MAP_3D);
+}
 
 void Game_ProcessKEvents(void)
 {
@@ -121,7 +128,7 @@ void Game_ProcessKEvents(void)
                         ascii_code = 0;
                     }
 
-                    if (Game_SwitchWSAD)
+                    if (Game_SwitchWSAD && Game_MovementEnabled())
                     {
                         switch(ascii_code)
                         {
@@ -243,7 +250,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_UP:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 'w';
                                 scancode = scancode_table[ascii_code];
@@ -259,7 +266,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_DOWN:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 's';
                                 scancode = scancode_table[ascii_code];
@@ -275,7 +282,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_RIGHT:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 'd';
                                 scancode = scancode_table[ascii_code];
@@ -291,7 +298,7 @@ void Game_ProcessKEvents(void)
 
                             break;
                         case SDLK_LEFT:
-                            if (Game_SwitchArrowKeys)
+                            if (Game_SwitchArrowKeys && Game_MovementEnabled())
                             {
                                 ascii_code = 'a';
                                 scancode = scancode_table[ascii_code];


### PR DESCRIPTION
(Depends on #82 for the `Game_Module` stack.)

The `Game_SwitchWSAD` settings is currently unusable because it applies globally, even when the game expects text input, and makes it impossible to type the letters W S A D.

This fixes it so that it applies only when a 2D or 3D screen is directly on top the game module stack, thus it will be in effect only when movement is expected.